### PR TITLE
Set texturepath Option

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,3 +1,5 @@
+import os
+
 def playerIcons(poi):
     if poi['id'] == 'Player':
         poi['icon'] = "https://overviewer.org/avatar/%s" % poi['EntityId']
@@ -12,6 +14,7 @@ def signFilter(poi):
 
 worlds['minecraft'] = "/home/minecraft/server/world"
 outputdir = "/home/minecraft/render/"
+texturepath = '/home/minecraft/{}.jar'.format(os.environ['MINECRAFT_VERSION'])
 
 markers = [
     dict(name="Players", filterFunction=playerIcons),

--- a/config/config.py
+++ b/config/config.py
@@ -1,9 +1,11 @@
 import os
 
+
 def playerIcons(poi):
     if poi['id'] == 'Player':
-        poi['icon'] = "https://overviewer.org/avatar/%s" % poi['EntityId']
-        return "Last known location for %s" % poi['EntityId']
+        poi['icon'] = "https://overviewer.org/avatar/{}".format(poi['EntityId'])
+        return "Last known location for {}".format(poi['EntityId'])
+
 
 # Only signs with "-- RENDER --" in them, and no others. Otherwise, people
 # can't have secret bases and the render is too busy anyways.
@@ -12,9 +14,10 @@ def signFilter(poi):
         if '-- RENDER --' in poi.values():
             return "\n".join([poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']])
 
+
 worlds['minecraft'] = "/home/minecraft/server/world"
 outputdir = "/home/minecraft/render/"
-texturepath = '/home/minecraft/{}.jar'.format(os.environ['MINECRAFT_VERSION'])
+texturepath = "/home/minecraft/{}.jar".format(os.environ['MINECRAFT_VERSION'])
 
 markers = [
     dict(name="Players", filterFunction=playerIcons),

--- a/download_url.py
+++ b/download_url.py
@@ -14,6 +14,7 @@ def get_json_from_url(url):
     response = urllib2.urlopen(request)
     return json.loads(response.read().decode())
 
+
 def get_minecraft_download_url(version):
     data = get_json_from_url(MANIFEST_URL)
 
@@ -28,6 +29,7 @@ def get_minecraft_download_url(version):
 
     download_url = data['downloads']['client']['url']
     return download_url
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument("version")


### PR DESCRIPTION
This is another proposal to #29 and #30. Fixes error messages around `texturepath` configuration option missing. 

```
...
2019-04-27 14:55:19 (10.5 MB/s) - '1.11.jar' saved [9183701/9183701]

2019-04-27 14:55:19  Welcome to Minecraft Overviewer!
2019-04-27 14:55:20  Generating textures...
*******************************************************************************
2019-04-27 14:55:20 E Could not find the textures while searching for 'assets/minecraft/textures/block/grass_block_top.png'. Try specifying the 'texturepath' option in your config file.
Set it to the path to a Minecraft Resource pack.
Alternately, install the Minecraft client (which includes textures)
Also see <http://docs.overviewer.org/en/latest/running/#installing-the-textures>
(Remember, this version of Overviewer requires a 1.14-compatible resource pack)
(Also note that I won't automatically use snapshots; you'll have to use the texturepath option to use a snapshot jar)
```