### PR TITLE
Split ADDITIONAL_ARGS and have ADDITIONAL_ARGS_POI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ docker run \
 - `ADDITIONAL_ARGS`
   Default Value: _null_. Set to contain any additional arguments you'd like to pass into `overviewer.py`.
 
+- `ADDITIONAL_ARGS_POI`
+  Default Value: _null_. Set to contain any additional arguments you'd like to pass into `overviewer.py --genpoi`.
+
 - `CONFIG_LOCATION`
   Default Value: `/home/minecraft/config.py`. Set to a different path to override the provided configuration. This only makes sense if you have a different configuration in a volume.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,5 +19,5 @@ fi
 
 # Render the POI
 if [ "$RENDER_POI" == "true" ]; then
-  overviewer.py --config "$CONFIG_LOCATION" --genpoi $ADDITIONAL_ARGS
+  overviewer.py --config "$CONFIG_LOCATION" --genpoi $ADDITIONAL_ARGS_POI
 fi


### PR DESCRIPTION
The goal of this is to be an easy fix for #45. This allows for users to still pass flags in, but have it per command. In this particular case, some flags are not accepted when running `--genpoi`. 