### PR TITLE
Parameterize Sign Filtering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ LABEL MAINTAINER = 'Mark Ide Jr (https://www.mide.io)'
 ENV RENDER_MAP true
 ENV RENDER_POI true
 
+# Only render signs including this string, leave blank to render all signs
+ENV RENDER_SIGNS_INCLUDE "-- RENDER --"
+
 ENV CONFIG_LOCATION /home/minecraft/config.py
 
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ docker run \
 
 - `RENDER_POI`
   Default Value: `true`. Set to `false` to disable rendering of POI (points of interest).
+
+- `RENDER_SIGNS_INCLUDE`
+  Default Value: `-- RENDER --`. Only signs with this string will be rendered. Useful for allowing hidden bases or decluttering the render. Set to an empty string (`""`) to render all signs.

--- a/config/config.py
+++ b/config/config.py
@@ -13,11 +13,13 @@ def playerIcons(poi):
 # reasons, but also so that people can have secret bases and to keep the render
 # fairly clean.
 def signFilter(poi):
+    # Because of how Overviewer reads this file, we must "import os" again here.
+    import os
     if poi['id'] in ['Sign', 'minecraft:sign']:
         sign_filter_string = os.environ.get('RENDER_SIGNS_INCLUDE', "")
         render_all_signs = len(sign_filter_string) == 0
         if render_all_signs or sign_filter_string in poi.values():
-            return "\n".join([poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']])
+            return "<br>".join([poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']])
 
 
 worlds['minecraft'] = "/home/minecraft/server/world"

--- a/config/config.py
+++ b/config/config.py
@@ -7,11 +7,16 @@ def playerIcons(poi):
         return "Last known location for {}".format(poi['EntityId'])
 
 
-# Only signs with "-- RENDER --" in them, and no others. Otherwise, people
-# can't have secret bases and the render is too busy anyways.
+# Only render the signs with the filter string (stored in environment variable
+# RENDER_SIGNS_INCLUDE) in them. If RENDER_SIGNS_INCLUDE is blank or unset,
+# render all signs. RENDER_SIGNS_INCLUDE defaults to "-- RENDER --" for historic
+# reasons, but also so that people can have secret bases and to keep the render
+# fairly clean.
 def signFilter(poi):
     if poi['id'] in ['Sign', 'minecraft:sign']:
-        if '-- RENDER --' in poi.values():
+        sign_filter_string = os.environ.get('RENDER_SIGNS_INCLUDE', "")
+        render_all_signs = len(sign_filter_string) == 0
+        if render_all_signs or sign_filter_string in poi.values():
             return "\n".join([poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']])
 
 

--- a/config/config.py
+++ b/config/config.py
@@ -19,7 +19,7 @@ def signFilter(poi):
         sign_filter_string = os.environ.get('RENDER_SIGNS_INCLUDE', "")
         render_all_signs = len(sign_filter_string) == 0
         if render_all_signs or sign_filter_string in poi.values():
-            return "<br>".join([poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']])
+            return "<br />".join([poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']])
 
 
 worlds['minecraft'] = "/home/minecraft/server/world"


### PR DESCRIPTION
This PR allows for the user to specify a string (previously hardcoded as `-- RENDER --`) to filter signs on. If they would like all signs to be filtered, the user can set the setting to an empty string.

This should solve #55, @magneticflux what do you think?