### PR TITLE
Add optipng to allow usage of `optimizeimg` option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV RENDER_POI true
 ENV CONFIG_LOCATION /home/minecraft/config.py
 
 RUN apt-get update && \
-    apt-get install -y wget gnupg && \
+    apt-get install -y wget gnupg optipng && \
     echo "deb http://overviewer.org/debian ./" >> /etc/apt/sources.list && \
     wget -O - https://overviewer.org/debian/overviewer.gpg.asc | apt-key add - && \
     apt-get update && \


### PR DESCRIPTION
My map render was about 90GB in size, over the past few days I've let optipng run over all 3068062 png files in it and the size was reduced to 60GB. Pretty good savings, so from now on I'd like to make use of the `optimizeimg` settings and optimize all new rendered images upon creation. For that to work, the optipng package needs to be available in the Docker container.

I'm only adding optipng because it's the only one I've ever used and I'm certain it's available in Debian as well. Let me know if you'd rather want to add all available optimizers at once.