### PR TITLE
Allow for Client Jar Caching

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -31,7 +31,6 @@ def signFilter(poi):
 
 worlds['minecraft'] = "/home/minecraft/server/world"
 outputdir = "/home/minecraft/render/"
-texturepath = "/home/minecraft/{}.jar".format(os.environ['MINECRAFT_VERSION'])
 
 markers = [
     dict(name="Players", filterFunction=playerIcons),

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,8 @@ if [ -f "/home/minecraft/.minecraft/versions/${MINECRAFT_VERSION}/${MINECRAFT_VE
 else
     CLIENT_URL=$(python3 /home/minecraft/download_url.py "${MINECRAFT_VERSION}")
     echo "Using Client URL ${CLIENT_URL} to download ${MINECRAFT_VERSION}.jar."
-    wget "${CLIENT_URL}" -O "${MINECRAFT_VERSION}.jar" -P /home/minecraft/.minecraft/versions/${MINECRAFT_VERSION}/
+    mkdir -p "/home/minecraft/.minecraft/versions/${MINECRAFT_VERSION}/"
+    wget "${CLIENT_URL}" -O "/home/minecraft/.minecraft/versions/${MINECRAFT_VERSION}/${MINECRAFT_VERSION}.jar"
 fi
 
 # Render the Map

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,24 @@ else
     wget "${CLIENT_URL}" -O "/home/minecraft/.minecraft/versions/${MINECRAFT_VERSION}/${MINECRAFT_VERSION}.jar"
 fi
 
+# DEPRECATION WARNING
+if grep -q "texturepath" "${CONFIG_LOCATION}"; then
+  NEW_LOCATION="/home/minecraft/.minecraft/versions/${MINECRAFT_VERSION}/${MINECRAFT_VERSION}.jar"
+  OLD_LOCATION="/home/minecraft/${MINECRAFT_VERSION}.jar"
+  echo "----------------------------------------------------------------------"
+  echo "                         DEPRECATION WARNING!                         "
+  echo "----------------------------------------------------------------------"
+  echo "The texture file location has changed and 'texturepath' set in your   "
+  echo "config.py! Either update your configuration to point to the new       "
+  echo "location, or remove that line. We will copy the texturepath into the  "
+  echo "old location for now. On or around July 31, 2020, we will drop support"
+  echo "for the old location.                                                 "
+  echo "Old Location: ${OLD_LOCATION}                                         "
+  echo "New Location: ${NEW_LOCATION}                                         "
+  echo "----------------------------------------------------------------------"
+  cp "${NEW_LOCATION}" "${OLD_LOCATION}"
+fi
+
 # Render the Map
 if [ "$RENDER_MAP" == "true" ]; then
   overviewer.py --config "$CONFIG_LOCATION" $ADDITIONAL_ARGS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ else
     wget "${CLIENT_URL}" -O "/home/minecraft/.minecraft/versions/${MINECRAFT_VERSION}/${MINECRAFT_VERSION}.jar"
 fi
 
-# DEPRECATION WARNING
+# DEPRECATION WARNING - TODO: Remove this block on or around July 31, 2020.
 if grep -q "texturepath" "${CONFIG_LOCATION}"; then
   NEW_LOCATION="/home/minecraft/.minecraft/versions/${MINECRAFT_VERSION}/${MINECRAFT_VERSION}.jar"
   OLD_LOCATION="/home/minecraft/${MINECRAFT_VERSION}.jar"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,9 +8,17 @@ if [ -z "$MINECRAFT_VERSION" ]; then
 fi
 
 # Download Minecraft client .jar (Contains textures used by Minecraft Overviewer)
-CLIENT_URL=$(python3 /home/minecraft/download_url.py "$MINECRAFT_VERSION")
-echo "Using Client URL $CLIENT_URL."
-wget -N "${CLIENT_URL}" -O "${MINECRAFT_VERSION}.jar" -P /home/minecraft/.minecraft/versions/${MINECRAFT_VERSION}/
+# We only download if the client doesn't exist. In most cases, it won't exist
+# because the directory isn't a volume and the Docker container will be a fresh
+# slate. This check enables power-users to mount the /home/minecraft/.minecraft/
+# directory and prevent downloading if the file exists.
+if [ -f "/home/minecraft/.minecraft/versions/${MINECRAFT_VERSION}/${MINECRAFT_VERSION}.jar" ]; then
+    echo "Minecraft client ${MINECRAFT_VERSION}.jar exists! Skipping download."
+else
+    CLIENT_URL=$(python3 /home/minecraft/download_url.py "${MINECRAFT_VERSION}")
+    echo "Using Client URL ${CLIENT_URL} to download ${MINECRAFT_VERSION}.jar."
+    wget "${CLIENT_URL}" -O "${MINECRAFT_VERSION}.jar" -P /home/minecraft/.minecraft/versions/${MINECRAFT_VERSION}/
+fi
 
 # Render the Map
 if [ "$RENDER_MAP" == "true" ]; then


### PR DESCRIPTION
This will solve #49.

**Note:** This deprecates the old texture path location in favor of the default. 