### PR TITLE
Remove Sign Padding

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -18,6 +18,11 @@ def signFilter(poi):
         hide_filter = os.environ['RENDER_SIGNS_HIDE_FILTER'] == 'true'
         # Transform the lines into an array and strip whitespace from each line.
         lines = list(map(lambda l: l.strip(),[poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']]))
+        # Remove all leading and trailing empty lines
+        while lines and not lines[0]:
+            del lines[0]
+        while lines and not lines[-1]:
+            del lines[-1]
         # Determine if we should render this sign
         render_all_signs = len(sign_filter) == 0
         render_this_sign = sign_filter in lines

--- a/config/config.py
+++ b/config/config.py
@@ -17,7 +17,7 @@ def signFilter(poi):
         sign_filter = os.environ['RENDER_SIGNS_FILTER']
         hide_filter = os.environ['RENDER_SIGNS_HIDE_FILTER'] == 'true'
         # Transform the lines into an array and strip whitespace from each line.
-        lines = list(map(lambda l: l.strip(),[poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']]))
+        lines = list(map(lambda l: l.strip(), [poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']]))
         # Remove all leading and trailing empty lines
         while lines and not lines[0]:
             del lines[0]


### PR DESCRIPTION
Remove padding around signs (any blank lines at start and end, but not in the middle).

----
Sanity Check:
```
def test(lines):
    # Remove all leading and trailing empty lines
    while lines and not lines[0]:
        del lines[0]
    while lines and not lines[-1]:
        del lines[-1]

    return lines

print("All expected True...")
print(test([""]) == [])
print(test(["", ""]) == [])
print(test([]) == [])
print(test(["foo"]) == ["foo"])
print(test(["foo", ""]) == ["foo"])
print(test(["", "", "foo", ""]) == ["foo"])
print(test(["bar", "", "foo", ""]) == ["bar", "", "foo"])
print(test(["bar", "", "foo"]) == ["bar", "", "foo"])
```

Result:
```
All expected True...
True
True
True
True
True
True
True
True
```