### PR TITLE
Autoversion

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -o errexit
 
-# Attempt to discover the latest version from the server logs
-MINECRAFT_VERSION=$(zgrep -h ": Starting minecraft server version " /home/minecraft/server/logs/* | awk 'NF>1{print $NF}' | sort | tail -1)
+# Attempt to discover the latest version from the server logs if not declared
+if [ -n "$MINECRAFT_VERSION" ]; then
+  MINECRAFT_VERSION=$(zgrep -h ": Starting minecraft server version " /home/minecraft/server/logs/* \
+    | awk 'NF>1{print $NF}' | sort | tail -1)
+fi
 
 # Require MINECRAFT_VERSION environment variable to be set (no default assumed)
 if [ -z "$MINECRAFT_VERSION" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -o errexit
 
+# Attempt to discover the latest version from the server logs
+MINECRAFT_VERSION=$(zgrep -h ": Starting minecraft server version " /home/minecraft/server/logs/* | awk 'NF>1{print $NF}' | sort | tail -1)
+
 # Require MINECRAFT_VERSION environment variable to be set (no default assumed)
 if [ -z "$MINECRAFT_VERSION" ]; then
   echo "Expecting environment variable MINECRAFT_VERSION to be set to non-empty string. Exiting."


### PR DESCRIPTION
Added logic to entrypoint.sh to attempt to discover the server version from a message in the log file on the server. Uses the latest one found or, if not found, requires it to be set from the  command line. 