### PR TITLE
Support Specifying "Latest" Version Keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker run \
 ### Required
 
 - `MINECRAFT_VERSION`
-  Set to the version of Minecraft the world is based from (Like `1.14.1`). Used for textures.
+  Set to the version of Minecraft the world is based from (Like `1.14.1`). Used for textures. You can also use the special version  `latest` or `latest_snapshot` to just use the latest version (stable or snapshot, respectively).
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker run \
 ### Required
 
 - `MINECRAFT_VERSION`
-  Set to the version of Minecraft the world is based from (Like `1.14.1`). Used for textures. You can also use the special version  `latest` or `latest_snapshot` to just use the latest version (stable or snapshot, respectively).
+  Set to the version of Minecraft the world is based from (Like `1.14.1`). Used for textures. You can also use the special version `latest` or `latest_snapshot` to just use the latest version (stable or snapshot, respectively).
 
 ### Optional
 

--- a/config/config.py
+++ b/config/config.py
@@ -26,7 +26,12 @@ def signFilter(poi):
         lines = list(
             map(
                 lambda l: l.strip(),
-                [poi["Text1"], poi["Text2"], poi["Text3"], poi["Text4"],],
+                [
+                    poi["Text1"],
+                    poi["Text2"],
+                    poi["Text3"],
+                    poi["Text4"],
+                ],
             )
         )
         # Remove all leading and trailing empty lines

--- a/download_url.py
+++ b/download_url.py
@@ -22,6 +22,13 @@ def get_json_from_url(url):
 def get_minecraft_download_url(version):
     data = get_json_from_url(MANIFEST_URL)
 
+    # Support to special-case versions, latest and latest_snapshot, which will
+    # always use the latest avaiable releases using the Minecraft Metadata.
+    if version == "latest":
+        version = data['latest']['release']
+    elif version == "latest_snapshot":
+        version = data['latest']['snapshot']
+
     desired_versions = list(filter(lambda v: v["id"] == version, data["versions"]))
     if len(desired_versions) == 0:
         raise RuntimeError(

--- a/download_url.py
+++ b/download_url.py
@@ -25,9 +25,9 @@ def get_minecraft_download_url(version):
     # Support to special-case versions, latest and latest_snapshot, which will
     # always use the latest avaiable releases using the Minecraft Metadata.
     if version == "latest":
-        version = data['latest']['release']
+        version = data["latest"]["release"]
     elif version == "latest_snapshot":
-        version = data['latest']['snapshot']
+        version = data["latest"]["snapshot"]
 
     desired_versions = list(filter(lambda v: v["id"] == version, data["versions"]))
     if len(desired_versions) == 0:


### PR DESCRIPTION
Brought up in #87, this introduces a way to support uses who want to pin to the "latest" version of Minecraft, whatever that may be at the time of the render. With this, we introduce two new special versions keywords, and when specified will take the latest versions of the Minecraft client from the metadata.