### PR TITLE
Switch to Git source for Overviewer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 
 FROM debian:stretch
 
-LABEL MAINTAINER='Mark Ide Jr (https://www.mide.io)'
+LABEL maintainer='Mark Ide Jr (https://www.mide.io)'
 
 # --------------- #
 # OPTION DEFAULTS #

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,42 +10,41 @@ FROM debian:stretch
 
 LABEL MAINTAINER='Mark Ide Jr (https://www.mide.io)'
 
-# Default to do both render Map + POI
-ENV RENDER_MAP true
-ENV RENDER_POI true
+# --------------- #
+# OPTION DEFAULTS #
+# --------------- #
 
-# Only render signs including this string, leave blank to render all signs
+# See README.md for description of these options
+ENV CONFIG_LOCATION /home/minecraft/config.py
+ENV RENDER_MAP "true"
+ENV RENDER_POI "true"
 ENV RENDER_SIGNS_FILTER "-- RENDER --"
-
-# Hide the filter string from the render
 ENV RENDER_SIGNS_HIDE_FILTER "false"
-
-# What to join the lines of the sign with when rendering POI
 ENV RENDER_SIGNS_JOINER "<br />"
 
-ENV CONFIG_LOCATION /home/minecraft/config.py
-
-# Hadolint DL4006: Set the SHELL option -o pipefail before RUN with a pipe in it
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# ---------------------------- #
+# INSTALL & CONFIGURE DEFAULTS #
+# ---------------------------- #
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates=20200601~deb9u2 wget=1.18-5+deb9u3 gnupg=2.1.18-8~deb9u4 optipng=0.7.6-1+deb9u1 && \
-    echo "deb http://overviewer.org/debian ./" >> /etc/apt/sources.list && \
-    wget -q -O - https://overviewer.org/debian/overviewer.gpg.asc | apt-key add - && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends minecraft-overviewer=0.16.12-0~overviewer1 && \
+    apt-get install -y --no-install-recommends ca-certificates wget optipng python3 build-essential git python3-dev python3-numpy python3-pillow && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     groupadd minecraft -g 1000 && \
     useradd -m minecraft -u 1000 -g 1000 && \
     mkdir -p /home/minecraft/render /home/minecraft/server
+
+WORKDIR /home/minecraft/
+
+RUN git clone --depth=1 git://github.com/overviewer/Minecraft-Overviewer.git && \
+    cd Minecraft-Overviewer/ && \
+    python3 setup.py build && \
+    python3 setup.py install
 
 COPY config/config.py /home/minecraft/config.py
 COPY entrypoint.sh /home/minecraft/entrypoint.sh
 COPY download_url.py /home/minecraft/download_url.py
 
 RUN chown minecraft:minecraft -R /home/minecraft/
-
-WORKDIR /home/minecraft/
 
 USER minecraft
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,19 +26,31 @@ ENV RENDER_SIGNS_JOINER "<br />"
 # INSTALL & CONFIGURE DEFAULTS #
 # ---------------------------- #
 
+WORKDIR /home/minecraft/
+
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates wget optipng python3 build-essential git python3-dev python3-numpy python3-pillow && \
+    apt-get install -y --no-install-recommends \
+        build-essential=12.3 \
+        ca-certificates=20200601~deb9u2 \
+        git=1:2.11.0-3+deb9u7 \
+        optipng=0.7.6-1+deb9u1 \
+        python3=3.5.3-1 \
+        python3-dev=3.5.3-1 \
+        python3-numpy=1:1.12.1-3 \
+        python3-pil=4.0.0-4+deb9u2 \
+        wget=1.18-5+deb9u3 && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     groupadd minecraft -g 1000 && \
     useradd -m minecraft -u 1000 -g 1000 && \
     mkdir -p /home/minecraft/render /home/minecraft/server
 
-WORKDIR /home/minecraft/
+RUN git clone --depth=1 git://github.com/overviewer/Minecraft-Overviewer.git
 
-RUN git clone --depth=1 git://github.com/overviewer/Minecraft-Overviewer.git && \
-    cd Minecraft-Overviewer/ && \
-    python3 setup.py build && \
+WORKDIR /home/minecraft/Minecraft-Overviewer/
+RUN python3 setup.py build && \
     python3 setup.py install
+
+WORKDIR /home/minecraft/
 
 COPY config/config.py /home/minecraft/config.py
 COPY entrypoint.sh /home/minecraft/entrypoint.sh


### PR DESCRIPTION
As mentioned previously (#80, #81, #84, perhaps others), we have wanted to switch to a Git source for Overviewer, so that we always get the latest changes & fixes. The Debian packages tend to lag behind. 