### PR TITLE
Support servers where the nether and the end are in separate folders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ ENV RENDER_POI "true"
 ENV RENDER_SIGNS_FILTER "-- RENDER --"
 ENV RENDER_SIGNS_HIDE_FILTER "false"
 ENV RENDER_SIGNS_JOINER "<br />"
+ENV WORLD_PATH "/home/minecraft/server/world"
+ENV NETHER_PATH "/home/minecraft/server/world"
+ENV END_PATH "/home/minecraft/server/world"
 
 # ---------------------------- #
 # INSTALL & CONFIGURE DEFAULTS #

--- a/README.md
+++ b/README.md
@@ -57,3 +57,10 @@ _Note:_ The `latest` Docker tag is rebuilt daily. If there are changes to the [u
 
 - `RENDER_SIGNS_JOINER`
   Default Value: `<br />`. Set to the string that should be used to join the lines on the sign while rendering. Value of `"<br />"` will make each in-game line it's own line on the render. A value of `" "` will make all the in-game lines a single line on the render.
+
+- `WORLD_PATH`
+  Default Value: `/home/minecraft/server/world`. Set to the path inside the container containing your overworld map.
+- `NETHER_PATH`
+  Default Value: `/home/minecraft/server/world`. Set to the path inside the container containing your nether map.
+- `END_PATH`
+  Default Value: `/home/minecraft/server/world`. Set to the path inside the container containing your end map.

--- a/config/config.py
+++ b/config/config.py
@@ -51,7 +51,9 @@ def signFilter(poi):
             return os.environ["RENDER_SIGNS_JOINER"].join(lines)
 
 
-worlds["minecraft"] = "/home/minecraft/server/world"
+worlds["world"] = os.environ["WORLD_PATH"]
+worlds["nether"] = os.environ["NETHER_PATH"]
+worlds["end"] = os.environ["END_PATH"]
 outputdir = "/home/minecraft/render/"
 
 markers = [
@@ -64,7 +66,7 @@ renders["day"] = {
     "dimension": "overworld",
     "markers": markers,
     "rendermode": "smooth_lighting",
-    "world": "minecraft",
+    "world": "world",
 }
 
 renders["night"] = {
@@ -72,7 +74,7 @@ renders["night"] = {
     "dimension": "overworld",
     "markers": markers,
     "rendermode": "smooth_night",
-    "world": "minecraft",
+    "world": "world",
 }
 
 renders["nether"] = {
@@ -80,7 +82,7 @@ renders["nether"] = {
     "dimension": "nether",
     "markers": markers,
     "rendermode": "nether_smooth_lighting",
-    "world": "minecraft",
+    "world": "nether",
 }
 
 renders["end"] = {
@@ -88,7 +90,7 @@ renders["end"] = {
     "dimension": "end",
     "markers": markers,
     "rendermode": [Base(), EdgeLines(), SmoothLighting(strength=0.5)],
-    "world": "minecraft",
+    "world": "end",
 }
 
 renders["overlay_biome"] = {
@@ -96,7 +98,7 @@ renders["overlay_biome"] = {
     "dimension": "overworld",
     "overlay": ["day"],
     "rendermode": [ClearBase(), BiomeOverlay()],
-    "world": "minecraft",
+    "world": "world",
 }
 
 renders["overlay_mobs"] = {
@@ -104,7 +106,7 @@ renders["overlay_mobs"] = {
     "dimension": "overworld",
     "overlay": ["day"],
     "rendermode": [ClearBase(), SpawnOverlay()],
-    "world": "minecraft",
+    "world": "world",
 }
 
 renders["overlay_slime"] = {
@@ -112,5 +114,5 @@ renders["overlay_slime"] = {
     "dimension": "overworld",
     "overlay": ["day"],
     "rendermode": [ClearBase(), SlimeOverlay()],
-    "world": "minecraft",
+    "world": "world",
 }


### PR DESCRIPTION
Some minecraft servers create separate folders for each of the worlds by default, and the included config fails to find those worlds. This updates that config to support separate folders for each world.