### PR TITLE
Add multi-arch docker build into build workflow

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -15,6 +15,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+    
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -25,4 +31,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: mide/minecraft-overviewer:latest


### PR DESCRIPTION
Regarding to #111 

I've modified and tested the ` builder.yaml` workflow to build and target amd64 and arm64 containers. I've tested the changes using the build-test branch on my fork, published the containers to docker ([jguizarj/minecraft-overviewer](https://hub.docker.com/r/jguizarj/minecraft-overviewer)), pulled and ran overviewer on both arm64 and amd64.

- Added `docker/setup-qemu-action@v1` and `docker/setup-buildx-action@v1` actions to support multi-arch build for the docker container
- Added platforms input to `docker/build-push-action@v2` action to target amd64 and arm64 architectures