### PR TITLE
Improve PR Builder and Fix `optipng`

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,18 +10,21 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+
       - name: Lint Code Base
         uses: github/super-linter@v5
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Build and push to Docker Hub
+
+      - name: Test Building Image
         uses: docker/build-push-action@v4
         with:
           push: false
           platforms: linux/amd64,linux/arm64
-          tags: mide/minecraft-overviewer:latest
           build-args: |
             GITHUB_REF="${{ github.ref }}"
             GITHUB_REPOSITORY="${{ github.repository }}"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,3 +12,17 @@ jobs:
         uses: actions/checkout@v3
       - name: Lint Code Base
         uses: github/super-linter@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v4
+        with:
+          push: false
+          platforms: linux/amd64,linux/arm64
+          tags: mide/minecraft-overviewer:latest
+          build-args: |
+            GITHUB_REF="${{ github.ref }}"
+            GITHUB_REPOSITORY="${{ github.repository }}"
+            GITHUB_SHA="${{ github.sha }}"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,7 +4,7 @@ name: Lint Code Base
 on: push
 
 jobs:
-  build:
+  lint:
     name: Lint Codebase
     runs-on: ubuntu-latest
     steps:
@@ -14,13 +14,17 @@ jobs:
       - name: Lint Code Base
         uses: github/super-linter@v5
 
+  build:
+    name: Test Build
+    runs-on: ubuntu-latest
+    steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Test Building Image
+      - name: Build Image
         uses: docker/build-push-action@v4
         with:
           push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update && \
         curl=7.74.0-1.3+deb11u7 \
         git=1:2.30.2-1+deb11u2 \
         jq=1.6-2.1 \
-        optipng=0.7.7-1 \
+        optipng=0.7.7-1+b1 \
         python3-dev=3.9.2-3 \
         python3-numpy=1:1.19.5-1 \
         python3-pil=8.1.2+dfsg-0.3+deb11u1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,12 +55,12 @@ RUN apt-get update && \
         curl=7.74.0-1.3+deb11u7 \
         git=1:2.30.2-1+deb11u2 \
         jq=1.6-2.1 \
-        optipng=0.7.7-1+b1 \
         python3-dev=3.9.2-3 \
         python3-numpy=1:1.19.5-1 \
         python3-pil=8.1.2+dfsg-0.3+deb11u1 \
         python3=3.9.2-3 \
         wget=1.21-1+deb11u1 && \
+    apt-get install -y --no-install-recommends optipng=0.7.7-1+b1 || apt-get install -y --no-install-recommends optipng=0.7.7-1 && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     groupadd minecraft -g 1000 && \
     useradd -m minecraft -u 1000 -g 1000 && \


### PR DESCRIPTION
It looks like `optipng` may have different versions depending on which architecture we're installing on. We'll just attempt either version. 