### PR TITLE
Add Maintenance Status Warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Docker Image to Run [Minecraft Overviewer](https://overviewer.org/). Overviewer 
 
 This project's code is hosted on [GitHub](https://github.com/mide/minecraft-overviewer), and the resulting Docker image is hosted on [Docker Hub](https://hub.docker.com/r/mide/minecraft-overviewer). Feel free to open [an issue on GitHub](https://github.com/mide/minecraft-overviewer/issues?q=is%3Aopen) if you're having problems.
 
+## :construction: Maintenance Status :construction:
+
+As of [April 5, 2023](https://github.com/overviewer/Minecraft-Overviewer/commit/13c1bddaf65dfaaf6c4c7a396c94db75bed4c089), the upstream Minecraft-Overviewer project is no longer being maintained. For more information on the matter, please check the project's [Official GitHub](https://github.com/overviewer/Minecraft-Overviewer).
+
 ## Running Minecraft Overviewer
 
 In the below example, `minecraft-overviewer` will read input in from `/home/user/path_to_minecraft_files/` and write the output to `/home/user/path_to_write_overviewer_output/`. It will run once and exit.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Docker Image to Run [Minecraft Overviewer](https://overviewer.org/). Overviewer 
 
 This project's code is hosted on [GitHub](https://github.com/mide/minecraft-overviewer), and the resulting Docker image is hosted on [Docker Hub](https://hub.docker.com/r/mide/minecraft-overviewer). Feel free to open [an issue on GitHub](https://github.com/mide/minecraft-overviewer/issues?q=is%3Aopen) if you're having problems.
 
-## :construction: Maintenance Status :construction:
+## :construction: Maintenance Status
 
 As of [April 5, 2023](https://github.com/overviewer/Minecraft-Overviewer/commit/13c1bddaf65dfaaf6c4c7a396c94db75bed4c089), the upstream Minecraft-Overviewer project is no longer being maintained. For more information on the matter, please check the project's [Official GitHub](https://github.com/overviewer/Minecraft-Overviewer).
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -o errexit
 
+# https://github.com/overviewer/Minecraft-Overviewer/commit/13c1bddaf65dfaaf6c4c7a396c94db75bed4c089
+echo "---------------------------------------------------------------------------"
+echo "                                  WARNING!                                 "
+echo "---------------------------------------------------------------------------"
+echo "The upstream Minecraft-Overviewer project is no longer being maintained.   "
+echo "As this project relies entirely on Minecraf-Overviewer, some known issues  "
+echo "may remain open. Check out the project's official page for more details:   "
+echo "https://github.com/overviewer/Minecraft-Overviewer                         "
+echo "---------------------------------------------------------------------------"
+
 # Require MINECRAFT_VERSION environment variable to be set (no default assumed)
 if [ -z "$MINECRAFT_VERSION" ]; then
   echo "Expecting environment variable MINECRAFT_VERSION to be set to non-empty string. Exiting."


### PR DESCRIPTION
The upstream project, Minecraft-Overviewer, is no longer being maintained (See https://github.com/overviewer/Minecraft-Overviewer/commit/13c1bddaf65dfaaf6c4c7a396c94db75bed4c089). This adds a maintenance status warnings to both the `README.md` and to the container at boot-time. 