### PR TITLE
Change where we pull Minecraft Overviewer from

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu
 # -------------------- #
 
 ARG GITHUB_REF
-ARG GITHUB_REPOSITORY
+ARG GITHUB_REPOSITORY="https://github.com/GregoryAM-SP/The-Minecraft-Overviewer.git"
 ARG GITHUB_SHA
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 
 LABEL OriginalAuthor='Mark Ide Jr (https://www.mide.io)'
 LABEL Maintainer="Derek Keeler <34773432+derek-keeler@users.noreply.github.com>"
@@ -50,10 +52,10 @@ RUN apt-get update && \
         optipng && \
     apt-get autoremove -y -q && \
     apt-get clean -y -q && \
-    groupadd minecraft -g 1000 && \
-    useradd -m minecraft -u 1000 -g 1000 && \
+    groupadd minecraft -g $GROUP_ID && \
+    useradd -m minecraft -u $USER_ID -g $GROUP_ID && \
     mkdir -p /home/minecraft/render /home/minecraft/server && \
-    git clone --depth=1 https://github.com/GregoryAM-SP/The-Minecraft-Overviewer Minecraft-Overviewer && \
+    git clone --depth=1 $GITHUB_REPOSITORY Minecraft-Overviewer && \
     cd Minecraft-Overviewer && \
     python3 setup.py build && \
     python3 setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # The Minecraft-Overviewer render will be output at
 #     /home/minecraft/render
 
-FROM debian:bullseye
+FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu
 
 # -------------------- #
 # BUILD-TIME ARGUMENTS #
@@ -16,7 +16,8 @@ ARG GITHUB_REF
 ARG GITHUB_REPOSITORY
 ARG GITHUB_SHA
 
-LABEL maintainer='Mark Ide Jr (https://www.mide.io)'
+LABEL OriginalAuthor='Mark Ide Jr (https://www.mide.io)'
+LABEL Maintainer="Derek Keeler <34773432+derek-keeler@users.noreply.github.com>"
 
 # --------------- #
 # OPTION DEFAULTS #
@@ -66,7 +67,7 @@ RUN apt-get update && \
     useradd -m minecraft -u 1000 -g 1000 && \
     mkdir -p /home/minecraft/render /home/minecraft/server
 
-RUN git clone --depth=1 https://github.com/overviewer/Minecraft-Overviewer.git
+RUN git clone --depth=1 https://github.com/GregoryAM-SP/The-Minecraft-Overviewer
 
 WORKDIR /home/minecraft/Minecraft-Overviewer/
 RUN python3 setup.py build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,12 @@ LABEL Maintainer="Derek Keeler <34773432+derek-keeler@users.noreply.github.com>"
 # --------------- #
 
 # See README.md for description of these options
-ENV CONFIG_LOCATION /home/minecraft/config.py
-ENV RENDER_MAP "true"
-ENV RENDER_POI "true"
-ENV RENDER_SIGNS_FILTER "-- RENDER --"
-ENV RENDER_SIGNS_HIDE_FILTER "false"
-ENV RENDER_SIGNS_JOINER "<br />"
+ENV CONFIG_LOCATION=/home/minecraft/config.py
+ENV RENDER_MAP="true"
+ENV RENDER_POI="true"
+ENV RENDER_SIGNS_FILTER="-- RENDER --"
+ENV RENDER_SIGNS_HIDE_FILTER="false"
+ENV RENDER_SIGNS_JOINER="<br/>"
 
 # ---------------------------- #
 # INSTALL & CONFIGURE DEFAULTS #
@@ -38,47 +38,29 @@ ENV RENDER_SIGNS_JOINER "<br />"
 WORKDIR /home/minecraft/
 
 RUN apt-get update && \
-    apt-cache madison \
+    apt-get upgrade -y -q && \
+    apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         curl \
         git \
         jq \
-        optipng \
-        python3-dev \
-        python3-numpy \
-        python3-pil \
-        python3 \
-        wget && \
-    apt-get install -y --no-install-recommends \
-        build-essential=12.9 \
-        ca-certificates=20210119 \
-        curl=7.74.0-1.3+deb11u7 \
-        git=1:2.30.2-1+deb11u2 \
-        jq=1.6-2.1 \
-        python3-dev=3.9.2-3 \
-        python3-numpy=1:1.19.5-1 \
-        python3-pil=8.1.2+dfsg-0.3+deb11u1 \
-        python3=3.9.2-3 \
-        wget=1.21-1+deb11u1 && \
-    apt-get install -y --no-install-recommends optipng=0.7.7-1+b1 || apt-get install -y --no-install-recommends optipng=0.7.7-1 && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+        python3-dev python3-numpy python3-pil python3 \
+        wget \
+        optipng && \
+    apt-get autoremove -y -q && \
+    apt-get clean -y -q && \
     groupadd minecraft -g 1000 && \
     useradd -m minecraft -u 1000 -g 1000 && \
-    mkdir -p /home/minecraft/render /home/minecraft/server
-
-RUN git clone --depth=1 https://github.com/GregoryAM-SP/The-Minecraft-Overviewer
-
-WORKDIR /home/minecraft/Minecraft-Overviewer/
-RUN python3 setup.py build && \
+    mkdir -p /home/minecraft/render /home/minecraft/server && \
+    git clone --depth=1 https://github.com/GregoryAM-SP/The-Minecraft-Overviewer Minecraft-Overviewer && \
+    cd Minecraft-Overviewer && \
+    python3 setup.py build && \
     python3 setup.py install
 
 WORKDIR /home/minecraft/
 
-COPY config/config.py /home/minecraft/config.py
-COPY entrypoint.sh /home/minecraft/entrypoint.sh
-COPY download_url.py /home/minecraft/download_url.py
-
+COPY config/config.py entrypoint.sh download_url.py /home/minecraft/
 # Add some timestamps / build information into the image
 RUN printf "GITHUB_REF=%s\nGITHUB_REPOSITORY=%s\nGITHUB_SHA=%s\nBUILD_DATE=$(date -u)\n" "$GITHUB_REF" "$GITHUB_REPOSITORY" "$GITHUB_SHA" > /home/minecraft/build-details.txt
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,29 @@
-# Minecraft Overviewer Docker Image
+# Minecraft Overviewer Docker Image Definition
 
-[![Docker](https://img.shields.io/docker/pulls/mide/minecraft-overviewer.svg)](https://hub.docker.com/r/mide/minecraft-overviewer/)
-[![Docker](https://img.shields.io/docker/stars/mide/minecraft-overviewer.svg)](https://hub.docker.com/r/mide/minecraft-overviewer/)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/mide/minecraft-overviewer/master/LICENSE)
-[![GitHub issues](https://img.shields.io/github/issues/mide/minecraft-overviewer.svg)](https://github.com/mide/minecraft-overviewer/issues)
+Docker Image definition to Run [Minecraft Overviewer](https://overviewer.org/). Overviewer is a render that produces a render of a [Minecraft](https://minecraft.net/en/) world. The goal of this image is to easily run the Overviewer project without having to worry about dependencies, and to provide sane default configurations.
 
-Docker Image to Run [Minecraft Overviewer](https://overviewer.org/). Overviewer is a render that produces a render of a [Minecraft](https://minecraft.net/en/) world. The goal of this image is to easily run the Overviewer project without having to worry about dependencies, and to provide sane default configurations.
-
-:warning: **This project is not official nor affiliated with the wonderful [Minecraft Overviewer](https://overviewer.org/) project**.
-
-This project's code is hosted on [GitHub](https://github.com/mide/minecraft-overviewer), and the resulting Docker image is hosted on [Docker Hub](https://hub.docker.com/r/mide/minecraft-overviewer). Feel free to open [an issue on GitHub](https://github.com/mide/minecraft-overviewer/issues?q=is%3Aopen) if you're having problems.
-
-## :construction: Maintenance Status
-
-As of [April 5, 2023](https://github.com/overviewer/Minecraft-Overviewer/commit/13c1bddaf65dfaaf6c4c7a396c94db75bed4c089), the upstream Minecraft-Overviewer project is no longer being maintained. For more information on the matter, please check the project's [Official GitHub](https://github.com/overviewer/Minecraft-Overviewer).
+:warning: **This project is not official nor affiliated with the wonderful [The Minecraft Overviewer | Successor](https://github.com/GregoryAM-SP/The-Minecraft-Overviewer) project**.
 
 ## Running Minecraft Overviewer
 
 In the below example, `minecraft-overviewer` will read input in from `/home/user/path_to_minecraft_files/` and write the output to `/home/user/path_to_write_overviewer_output/`. It will run once and exit.
 
 ```shell
-docker pull mide/minecraft-overviewer:latest
+docker build -t local/the-minecraft-overviewer:latest -f Dockerfile .
 docker run \
   --rm \
-  -e MINECRAFT_VERSION="1.19.4" \
+  -e MINECRAFT_VERSION="26.1" \
   -v /home/user/path_to_minecraft_files/:/home/minecraft/server/:ro \
   -v /home/user/path_to_write_overviewer_output/:/home/minecraft/render/:rw \
-  mide/minecraft-overviewer:latest
+  local/minecraft-overviewer:latest
 ```
-
-_Note:_ The `latest` Docker tag is rebuilt daily. If there are changes to the [upstream project](https://github.com/overviewer/Minecraft-Overviewer/), it may take up to 24 hours for the new image to contain them.
 
 ## Environment Variables
 
 ### Required
 
 - `MINECRAFT_VERSION`
-  Set to the version of Minecraft the world is based from (Like `1.17`). Used for textures. You can also use the special version `latest` or `latest_snapshot` to just use the latest version (stable or snapshot, respectively).
+  Set to the version of Minecraft the world is based from (Like `26.1`). Used for textures. You can also use the special version `latest` or `latest_snapshot` to just use the latest version (stable or snapshot, respectively).
 
 ### Optional
 
@@ -63,6 +50,13 @@ _Note:_ The `latest` Docker tag is rebuilt daily. If there are changes to the [u
 
 - `RENDER_SIGNS_JOINER`
   Default Value: `<br />`. Set to the string that should be used to join the lines on the sign while rendering. Value of `"<br />"` will make each in-game line it's own line on the render. A value of `" "` will make all the in-game lines a single line on the render.
+
+- `GROUP_ID`
+  Default Value: `1000`. Set this to the value of the group that should have access to the output folder. You will only need to do this if the user who owns the folder on the system you are running on is different than the default (for example, a special `minecraft:minecraft` group:user combination).
+
+- `USER_ID`
+  Default Value: `1000`. Set this to the value of the user ID that should have access to the output folder. You will only need to do this if the user who owns the folder on the system you are running on is different than the default (for example, a special `minecraft:minecraft` group:user combination).
+
 
 ## Mapped Directories / Volumes
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,123 @@
+# This config variable is loaded into the upstream Minecraft Overviewer project,
+# so it contains undefined variables and some `import` lines.
+# flake8: noqa: F821,F401
+# pylint: disable=undefined-variable
+# type: ignore
+
+# Regarding `global`, see
+# https://docs.overviewer.org/en/latest/signs/#filter-functions
+global html
+import html
+import os
+
+
+def playerIcons(poi):
+    if poi["id"] == "Player":
+        poi["icon"] = "https://overviewer.org/avatar/{}".format(poi["EntityId"])
+        return "Last known location for {}".format(poi["EntityId"])
+
+
+# Only render the signs with the filter string in them. If filter string is
+# blank or unset, render all signs. Lines are joined with a configurable string.
+def signFilter(poi):
+    # Because of how Overviewer reads this file, we must "import os" again here.
+    import os
+
+    # Only render signs with this function
+    if poi["id"] in ["sign", "minecraft:sign"]:
+        if 'Text1' in poi:
+            text_lines = [line for line in [poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']] if line.strip()]
+            print("Found pre-1.20 sign")
+        else:
+            # v1.20+ sign filter
+            text_lines = []
+            front_text = poi.get('front_text', {})
+            back_text = poi.get('back_text', {})
+            
+            text_lines.extend(line for line in front_text.get('messages', []) if line.strip())
+            text_lines.extend(line for line in back_text.get('messages', []) if line.strip())
+            print("found post-1.20 sign")
+
+        sign_filter = os.environ["RENDER_SIGNS_FILTER"]
+        #hide_filter = os.environ["RENDER_SIGNS_HIDE_FILTER"] == "true"
+        hide_filter = True
+        
+        # Determine if we should render this sign
+        render_all_signs = len(sign_filter) == 0
+        render_this_sign = sign_filter in text_lines
+        print(f"render_all_signs={render_all_signs}, render_this_sign={render_this_sign}")
+
+        if render_all_signs or render_this_sign:
+            print(f"Rending sign with text [{'/n'.join(text_lines)}]")
+            # If the user wants to strip the filter string, we do that here. Only
+            # do this if sign_filter isn't blank.
+            if hide_filter and not render_all_signs:
+                print('hiding the filter...')
+                text_lines = list(filter(lambda l: l != sign_filter, text_lines))
+
+            # return html.escape(os.environ["RENDER_SIGNS_JOINER"].join(text_lines))
+            return html.escape("\n".join(text_lines))
+
+worlds["minecraft"] = "/home/minecraft/server/world"
+outputdir = "/home/minecraft/render/"
+
+markers = [
+    dict(name="Players", filterFunction=playerIcons),
+    dict(name="Signs", filterFunction=signFilter),
+]
+
+renders["day"] = {
+    "title": "Day",
+    "dimension": "overworld",
+    "markers": markers,
+    "rendermode": "smooth_lighting",
+    "world": "minecraft",
+}
+
+renders["night"] = {
+    "title": "Night",
+    "dimension": "overworld",
+    "markers": markers,
+    "rendermode": "smooth_night",
+    "world": "minecraft",
+}
+
+renders["nether"] = {
+    "title": "Nether",
+    "dimension": "nether",
+    "markers": markers,
+    "rendermode": "nether_smooth_lighting",
+    "world": "minecraft",
+}
+
+renders["end"] = {
+    "title": "End",
+    "dimension": "end",
+    "markers": markers,
+    "rendermode": [Base(), EdgeLines(), SmoothLighting(strength=0.5)],
+    "world": "minecraft",
+}
+
+renders["overlay_biome"] = {
+    "title": "Biome Coloring Overlay",
+    "dimension": "overworld",
+    "overlay": ["day"],
+    "rendermode": [ClearBase(), BiomeOverlay()],
+    "world": "minecraft",
+}
+
+renders["overlay_mobs"] = {
+    "title": "Mob Spawnable Areas Overlay",
+    "dimension": "overworld",
+    "overlay": ["day"],
+    "rendermode": [ClearBase(), SpawnOverlay()],
+    "world": "minecraft",
+}
+
+renders["overlay_slime"] = {
+    "title": "Slime Chunk Overlay",
+    "dimension": "overworld",
+    "overlay": ["day"],
+    "rendermode": [ClearBase(), SlimeOverlay()],
+    "world": "minecraft",
+}

--- a/config/config.py
+++ b/config/config.py
@@ -24,9 +24,10 @@ def signFilter(poi):
     import os
 
     # Only render signs with this function
-    if poi["id"] in ["Sign", "minecraft:sign"]:
+    if poi["id"] in ["sign", "minecraft:sign"]:
         if 'Text1' in poi:
             text_lines = [line for line in [poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']] if line.strip()]
+            print("Found pre-1.20 sign")
         else:
             # v1.20+ sign filter
             text_lines = []
@@ -35,20 +36,27 @@ def signFilter(poi):
             
             text_lines.extend(line for line in front_text.get('messages', []) if line.strip())
             text_lines.extend(line for line in back_text.get('messages', []) if line.strip())
+            print("found post-1.20 sign")
 
         sign_filter = os.environ["RENDER_SIGNS_FILTER"]
-        hide_filter = os.environ["RENDER_SIGNS_HIDE_FILTER"] == "true"
+        #hide_filter = os.environ["RENDER_SIGNS_HIDE_FILTER"] == "true"
+        hide_filter = True
         
         # Determine if we should render this sign
         render_all_signs = len(sign_filter) == 0
         render_this_sign = sign_filter in text_lines
+        print(f"render_all_signs={render_all_signs}, render_this_sign={render_this_sign}")
+
         if render_all_signs or render_this_sign:
+            print(f"Rending sign with text [{'/n'.join(text_lines)}]")
             # If the user wants to strip the filter string, we do that here. Only
             # do this if sign_filter isn't blank.
             if hide_filter and not render_all_signs:
+                print('hiding the filter...')
                 text_lines = list(filter(lambda l: l != sign_filter, text_lines))
-                return html.escape(os.environ["RENDER_SIGNS_JOINER"].join(text_lines))
 
+            # return html.escape(os.environ["RENDER_SIGNS_JOINER"].join(text_lines))
+            return html.escape("\n".join(text_lines))
 
 worlds["minecraft"] = "/home/minecraft/server/world"
 outputdir = "/home/minecraft/render/"

--- a/config/config.py
+++ b/config/config.py
@@ -25,34 +25,29 @@ def signFilter(poi):
 
     # Only render signs with this function
     if poi["id"] in ["Sign", "minecraft:sign"]:
+        if 'Text1' in poi:
+            text_lines = [line for line in [poi['Text1'], poi['Text2'], poi['Text3'], poi['Text4']] if line.strip()]
+        else:
+            # v1.20+ sign filter
+            text_lines = []
+            front_text = poi.get('front_text', {})
+            back_text = poi.get('back_text', {})
+            
+            text_lines.extend(line for line in front_text.get('messages', []) if line.strip())
+            text_lines.extend(line for line in back_text.get('messages', []) if line.strip())
+
         sign_filter = os.environ["RENDER_SIGNS_FILTER"]
         hide_filter = os.environ["RENDER_SIGNS_HIDE_FILTER"] == "true"
-        # Transform the lines into an array and strip whitespace from each line.
-        lines = list(
-            map(
-                lambda l: l.strip(),
-                [
-                    poi["Text1"],
-                    poi["Text2"],
-                    poi["Text3"],
-                    poi["Text4"],
-                ],
-            )
-        )
-        # Remove all leading and trailing empty lines
-        while lines and not lines[0]:
-            del lines[0]
-        while lines and not lines[-1]:
-            del lines[-1]
+        
         # Determine if we should render this sign
         render_all_signs = len(sign_filter) == 0
-        render_this_sign = sign_filter in lines
+        render_this_sign = sign_filter in text_lines
         if render_all_signs or render_this_sign:
             # If the user wants to strip the filter string, we do that here. Only
             # do this if sign_filter isn't blank.
             if hide_filter and not render_all_signs:
-                lines = list(filter(lambda l: l != sign_filter, lines))
-            return html.escape(os.environ["RENDER_SIGNS_JOINER"].join(lines))
+                text_lines = list(filter(lambda l: l != sign_filter, text_lines))
+                return html.escape(os.environ["RENDER_SIGNS_JOINER"].join(text_lines))
 
 
 worlds["minecraft"] = "/home/minecraft/server/world"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,12 +3,8 @@ set -o errexit
 
 # https://github.com/overviewer/Minecraft-Overviewer/commit/13c1bddaf65dfaaf6c4c7a396c94db75bed4c089
 echo "---------------------------------------------------------------------------"
-echo "                                  WARNING!                                 "
-echo "---------------------------------------------------------------------------"
-echo "The upstream Minecraft-Overviewer project is no longer being maintained.   "
-echo "As this project relies entirely on Minecraf-Overviewer, some known issues  "
-echo "may remain open. Check out the project's official page for more details:   "
-echo "https://github.com/overviewer/Minecraft-Overviewer                         "
+echo "Check out the project's official page for more details:                    "
+echo "https://github.com/GregoryAM-SP/The-Minecraft-Overviewer                   "
 echo "---------------------------------------------------------------------------"
 
 # Require MINECRAFT_VERSION environment variable to be set (no default assumed)


### PR DESCRIPTION
Updates:

- Retarget the project to Minecraft Overviewer | Successor (the original project has been abandoned).
- Update sign-filter handling in config.py to handle signs from Minecraft > 1.20
- Update README with state of my fork

NOTE: _I do not expect anyone to pick this up, but I feel awful for not sharing!_
